### PR TITLE
Fixing timestamp so writing to azure works

### DIFF
--- a/azure/lib/archive.js
+++ b/azure/lib/archive.js
@@ -1,4 +1,5 @@
-var azure = require('azure');
+var azure = require('azure')
+  , moment = require('moment');
 
 var TABLE_NAME = "messages";
 
@@ -26,7 +27,7 @@ AzureArchiveProvider.prototype.archive = function(message, callback) {
     var messageObject = message.toObject();
 
     messageObject.PartitionKey = messageObject.from;
-    messageObject.RowKey = messageObject.ts;
+    messageObject.RowKey = moment(message.ts).utc().format();
 
     messageObject.body = JSON.stringify(messageObject.body);
     messageObject.tags = JSON.stringify(messageObject.tags);

--- a/azure/package.json
+++ b/azure/package.json
@@ -21,6 +21,7 @@
     "async": "^0.2.10",
     "azure": "^0.9.16",
     "nitrogen": "^0.2.23",
+    "moment": "~2.7.0",
     "sift": "^0.2.3",
     "node-amqp-1-0": "noodlefrenzy/node-amqp-1-0",
     "node-amqp-encoder": "noodlefrenzy/node-amqp-encoder",


### PR DESCRIPTION
This has fixed the write errors to azure tables.

I'm now able to debug why tests aren't working while I sort out the most efficient way to flatten the body.